### PR TITLE
[철회] 계정 삭제와 게시글 삭제

### DIFF
--- a/src/pages/Admin/components/AdminContainer.tsx
+++ b/src/pages/Admin/components/AdminContainer.tsx
@@ -19,7 +19,7 @@ const AdminContainer = () => {
     url: `https://togedog-dj.herokuapp.com/${params.value}`,
     headers: {
       accept: '*/*',
-      Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2MTkzMjQ3MiwiaWF0IjoxNjYxODQ2MDcyfQ.4sZDdEt11wNtcY9LReYGouDU4EU_F3mbRDrCRa_SSFw`,
+      Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDQzMzI3OSwiaWF0IjoxNjYxODQxMjc5fQ.NLpkWBcxdD98g5XTAUTbzwKz5TmVGzwanhjTLeoiWwM`,
     },
   });
 

--- a/src/pages/Admin/components/Modal/PostModal.tsx
+++ b/src/pages/Admin/components/Modal/PostModal.tsx
@@ -1,17 +1,37 @@
 import styled from 'styled-components';
+import { useState } from 'react';
 import useAxios from 'hooks/useAxios';
+import axios from 'axios';
 import { AiOutlineClose } from 'react-icons/ai';
 import UserInfoBox from 'pages/Admin/components/RightSection/UserInfoBox';
 
 const PostModal = ({ closeModal, modalId }) => {
+  const [reason, setReason] = useState<string>('');
+
   const { response } = useAxios({
     method: 'GET',
     url: `https://togedog-dj.herokuapp.com/posts/${modalId}`,
     headers: {
       accept: '*/*',
-      Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2MTkzMjQ3MiwiaWF0IjoxNjYxODQ2MDcyfQ.4sZDdEt11wNtcY9LReYGouDU4EU_F3mbRDrCRa_SSFw`,
+      Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDQzMzI3OSwiaWF0IjoxNjYxODQxMjc5fQ.NLpkWBcxdD98g5XTAUTbzwKz5TmVGzwanhjTLeoiWwM`,
     },
   });
+
+  const getReason = e => {
+    e.preventDefault();
+    setReason(e.target.value);
+  };
+
+  const deletePost = () => {
+    axios.delete(`https://togedog-dj.herokuapp.com/posts/${modalId}`, {
+      headers: {
+        Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDQzMzI3OSwiaWF0IjoxNjYxODQxMjc5fQ.NLpkWBcxdD98g5XTAUTbzwKz5TmVGzwanhjTLeoiWwM`,
+      },
+      data: {
+        ban: reason,
+      },
+    });
+  };
 
   return (
     <ModalBackground onClick={closeModal}>
@@ -46,9 +66,16 @@ const PostModal = ({ closeModal, modalId }) => {
             </PostImage>
             <ReasonToBan>
               <ReasonToBanTitle>사유</ReasonToBanTitle>
-              <ReasonToBanContent />
+              <ReasonToBanContent onChange={getReason} />
               <BtnWrapper>
-                <CancelBtn onClick={closeModal}>게시글 삭제</CancelBtn>
+                <CancelBtn
+                  onClick={() => {
+                    closeModal();
+                    deletePost();
+                  }}
+                >
+                  게시글 삭제
+                </CancelBtn>
               </BtnWrapper>
             </ReasonToBan>
           </ModalContentsWrapper>

--- a/src/pages/Admin/components/Modal/UserModal.tsx
+++ b/src/pages/Admin/components/Modal/UserModal.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import useAxios from 'hooks/useAxios';
+import axios from 'axios';
 import { AiOutlineClose } from 'react-icons/ai';
 
 const UserModal = ({ closeModal, modalId }) => {
@@ -8,9 +9,17 @@ const UserModal = ({ closeModal, modalId }) => {
     url: `https://togedog-dj.herokuapp.com/users/${modalId}`,
     headers: {
       accept: '*/*',
-      Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2MTkzMjQ3MiwiaWF0IjoxNjYxODQ2MDcyfQ.4sZDdEt11wNtcY9LReYGouDU4EU_F3mbRDrCRa_SSFw`,
+      Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDQzMzI3OSwiaWF0IjoxNjYxODQxMjc5fQ.NLpkWBcxdD98g5XTAUTbzwKz5TmVGzwanhjTLeoiWwM`,
     },
   });
+
+  const deleteUser = () => {
+    axios.delete(`https://togedog-dj.herokuapp.com/users/${modalId}`, {
+      headers: {
+        Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDQzMzI3OSwiaWF0IjoxNjYxODQxMjc5fQ.NLpkWBcxdD98g5XTAUTbzwKz5TmVGzwanhjTLeoiWwM`,
+      },
+    });
+  };
   return (
     <ModalBackground onClick={closeModal}>
       {response?.data && (
@@ -21,7 +30,7 @@ const UserModal = ({ closeModal, modalId }) => {
             </DeleteIconButton>
           </ModalTop>
           <ModalContents>
-            <ProfileImage></ProfileImage>
+            <ProfileImage />
             <UserName>{response.data.name}</UserName>
             <UserNickName>{response.data.nickname}</UserNickName>
             <Mbti>{response.data.mbti}</Mbti>
@@ -29,7 +38,14 @@ const UserModal = ({ closeModal, modalId }) => {
             <UserEmail>{response.data.email}</UserEmail>
             <UserAddress>경기도 서울시 부산구 대구동 73</UserAddress>
             <BtnContainer>
-              <CancelBtn onClick={closeModal}>계정 삭제</CancelBtn>
+              <CancelBtn
+                onClick={() => {
+                  closeModal();
+                  deleteUser();
+                }}
+              >
+                계정 삭제
+              </CancelBtn>
             </BtnContainer>
           </ModalContents>
         </ModalContainer>

--- a/src/pages/Admin/components/RightSection/AdminRightPagePost.tsx
+++ b/src/pages/Admin/components/RightSection/AdminRightPagePost.tsx
@@ -10,7 +10,7 @@ import { PagenatedData } from 'types/type';
 const AdminRightPagePost = ({ response }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
-  const [perPage, setPerPage] = useState(10);
+  const perPage = 10;
   const [indexClicked, setIndexClicked] = useState('');
   const [allToggle, setAllToggle] = useState(false);
   const [banToggle, setBanToggle] = useState(false);

--- a/src/pages/Admin/components/RightSection/AdminRightPageUser.tsx
+++ b/src/pages/Admin/components/RightSection/AdminRightPageUser.tsx
@@ -10,7 +10,7 @@ import { PagenatedData } from 'types/type';
 const AdminRightPageUser = ({ response }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
-  const [perPage, setPerPage] = useState(10);
+  const perPage = 10;
   const [indexClicked, setIndexClicked] = useState('');
   const [allToggle, setAllToggle] = useState(false);
   const [banToggle, setBanToggle] = useState(false);


### PR DESCRIPTION
### :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

### :: 구현 목표 
- 유저 리스트의 계정을 삭제합니다.
- 게시글 리스트의 게시글을 삭제하면서 사유를 함께 백엔드에 전달합니다.

<br />
<img width="760" alt="스크린샷 2022-09-01 오전 10 26 39" src="https://user-images.githubusercontent.com/101853832/187812817-b84b8374-80bf-40e8-b3b1-e7f70c516a88.png">

### :: 구현 사항
- 관리자 권한으로 계정을 삭제
- 게시글 삭제와 함께 사유를 백엔드단에 전달.


