### PR TITLE
[성주] 구글 소셜 로그인

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
-REACT_APP_REST_API_KEY='cea764c467cfdcf80407a08eefbcf5a4'
-REACT_APP_REDIRECT_URI='http://localhost:3000/kakaoLogin'
+REACT_APP_GOOGLE_CLIENT_ID = '479657448577-ci2a55955vc6p62kvlm8gb583s04u4ah.apps.googleusercontent.com'
+REACT_APP_GOOGLE_CLIENT_SECRET ='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'
+REACT_APP_GOOGLE_REDIRECT_URI='http://localhost:3000/googleLogin'
+REACT_AP_REST_API_KEY = 'cea764c467cfdcf80407a08eefbcf5a4'
+REACT_APP_REDIRECT_URI = 'http://localhost:3000/kakaoLogin'

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -6,7 +6,8 @@ import NoticeBoard from 'pages/NoticeBoard/NoticeBoard';
 import MainRouter from './pages/MainRouter/MainRouter';
 import Main from 'pages/Main/Main';
 import ChatRoom from 'pages/Chatting/ChatRoom';
-import KakaoLogin from 'pages/Login/SignIn/kakaoLogin/KakaoLogin';
+import KakaoLogin from 'pages/Login/SignIn/kakaoLogin/KakaoLoginRedirect';
+import GoogleLogin from 'pages/Login/SignIn/googleLogin/GoogleRedirect';
 
 const Router = () => {
   return (
@@ -20,6 +21,7 @@ const Router = () => {
         <Route path="/admin/:value/*" element={<Admin />} />
         <Route path="/chat" element={<ChatRoom />} />
         <Route path="/kakaoLogin" element={<KakaoLogin />} />
+        <Route path="/googleLogin" element={<GoogleLogin />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/Login/SignIn/googleLogin/GoogleRedirect.tsx
+++ b/src/pages/Login/SignIn/googleLogin/GoogleRedirect.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Spinner from 'pages/Login/components/spinner/Spinner';
+
+const GoogleRedirect = () => {
+  const navigate = useNavigate();
+  const GOOGLE_CODE = new URL(window.location.href).searchParams.get('code');
+
+  const handleGoogleToken = () => {
+    fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `grant_type=authorization_code&code=${GOOGLE_CODE}&client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&client_secret=${process.env.REACT_APP_GOOGLE_CLIENT_SECRET}&redirect_uri=${process.env.REACT_APP_GOOGLE_REDIRECT_URI}`,
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (data.access_token) {
+          const ACCESS_TOKEN = data.access_token;
+          fetch('https://togedog-dj.herokuapp.com/users/test/googletoken/', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              token: ACCESS_TOKEN,
+            }),
+          })
+            .then(res => res.json())
+            .then(result => {
+              localStorage.setItem('token', result.access_token);
+              navigate('/');
+            });
+        } else {
+          alert('구글 로그인 실패하셨습니다!');
+          navigate('/signin');
+        }
+      });
+  };
+
+  useEffect(() => {
+    handleGoogleToken();
+  });
+  return <Spinner />;
+};
+
+export default GoogleRedirect;

--- a/src/pages/Login/SignIn/googleLogin/GoogleloginData.tsx
+++ b/src/pages/Login/SignIn/googleLogin/GoogleloginData.tsx
@@ -1,0 +1,1 @@
+export const GOOGLE_AUTH_PATH = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_GOOGLE_REDIRECT_URI}&response_type=code&scope=https://www.googleapis.com/auth/userinfo.email profile`;

--- a/src/pages/Login/SignIn/index.tsx
+++ b/src/pages/Login/SignIn/index.tsx
@@ -1,4 +1,6 @@
 import styled from 'styled-components';
+import { KAKAO_AUTH_PATH } from './kakaoLogin/KakaoLoginData';
+import { GOOGLE_AUTH_PATH } from './googleLogin/GoogleloginData';
 import signInbg from 'assets/images/bg1.jpg';
 import googleIcon from 'assets/svg/google-logo.svg';
 import kakaoIcon from 'assets/svg/kakao-logo.svg';
@@ -6,11 +8,13 @@ import InputForm from '../components/inputForm/InputForm';
 import LoginButton from '../components/loginButton/LoginButton';
 import SNSButton from '../components/snsButton/SNSButton';
 import character from 'assets/images/LoginBgCharacter.png';
-import { KAKAO_AUTH_PATH } from './kakaoLogin/KakaoLoginData';
 
 const SignIn = () => {
   const handleKakaoLogin = () => {
     window.location.href = KAKAO_AUTH_PATH;
+  };
+  const handleGoogleLogin = () => {
+    window.location.href = GOOGLE_AUTH_PATH;
   };
 
   return (
@@ -30,12 +34,12 @@ const SignIn = () => {
           <SNSButton
             title="구글"
             icon={googleIcon}
-            handleKakaoLogin={handleKakaoLogin}
+            handleSNSLogin={handleGoogleLogin}
           />
           <SNSButton
             title="카카오"
             icon={kakaoIcon}
-            handleKakaoLogin={handleKakaoLogin}
+            handleSNSLogin={handleKakaoLogin}
           />
         </SnsLoginContainer>
       </LoginForm>

--- a/src/pages/Login/SignIn/kakaoLogin/KakaoLoginRedirect.tsx
+++ b/src/pages/Login/SignIn/kakaoLogin/KakaoLoginRedirect.tsx
@@ -2,11 +2,11 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Spinner from '../../components/spinner/Spinner';
 
-const KakaoLogin = () => {
+const KakaoLoginRedirect = () => {
   const navigate = useNavigate();
   const KAKAO_CODE = new URL(window.location.href).searchParams.get('code');
 
-  const getAndSendKakaoToken = () => {
+  const handleKakaoToken = () => {
     fetch('https://kauth.kakao.com/oauth/token', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -16,7 +16,7 @@ const KakaoLogin = () => {
       .then(data => {
         if (data.access_token) {
           const ACCESS_TOKEN = data.access_token;
-          fetch('https://togedog-dj.herokuapp.com/users/test/kakaotoken', {
+          fetch('https://togedog-dj.herokuapp.com/users/test/kakaotoken/', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -36,10 +36,10 @@ const KakaoLogin = () => {
   };
 
   useEffect(() => {
-    getAndSendKakaoToken();
+    handleKakaoToken();
   });
 
   return <Spinner />;
 };
 
-export default KakaoLogin;
+export default KakaoLoginRedirect;

--- a/src/pages/Login/components/SNSButton/SNSButton.tsx
+++ b/src/pages/Login/components/SNSButton/SNSButton.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import { SNSButtonProp } from 'types/type';
 
-const SNSButton = ({ title, icon, handleKakaoLogin }: SNSButtonProp) => {
+const SNSButton = ({ title, icon, handleSNSLogin }: SNSButtonProp) => {
   return (
-    <SnsButton onClick={handleKakaoLogin}>
+    <SnsButton onClick={handleSNSLogin}>
       <SnsIcon src={icon} />
       <SnsLogin>{title} 로그인</SnsLogin>
     </SnsButton>

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -21,7 +21,7 @@ export interface LoginButtonProp {
 export interface SNSButtonProp {
   title: string;
   icon: string;
-  handleKakaoLogin: () => void;
+  handleSNSLogin: () => void;
 }
 
 export interface PageBoxProp {


### PR DESCRIPTION
### :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

### :: 구현 목표 
-  구글 소셜 로그인 구현

<br />

### :: 구현 사항
<img width="770" alt="스크린샷 2022-09-07 오후 1 41 33" src="https://user-images.githubusercontent.com/97432901/188790318-61e7aeb7-233c-4e81-a18b-a53df32ff218.png">



1. 구글 소셜 로그인

📌 프론트엔드에서 Access Token을 받아오는 과정까지 구현
- 구글에서 인가 코드 받기
- 구글에서 받은 인가 코드를 이용하여 구글에게 다시 보내서 토큰 요청
- 구글에서 받은 access토큰을 서버에 전달
- 서버로부터 서버 전용 토큰 받기

<br />

### :: 특이 사항
- 우선적으로 구글 토큰을 받고 서버에게 보내는 과정까지 구현 완료
- 서버 전용 토큰을 localStorage에 저장하는 방식이 아닌 어떠한 다른 방식으로 저장할지 논의 필요 (보안적인 문제 고려 필수)
- 가독성을 위한 함수명, props명, 폴더명 변경