### PR TITLE
[철회] 페이지네이션 로직 수정 및 로그인 UI 추가

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -8,6 +8,7 @@ import Main from 'pages/Main/Main';
 import ChatRoom from 'pages/Chatting/ChatRoom';
 import KakaoLogin from 'pages/Login/SignIn/kakaoLogin/KakaoLoginRedirect';
 import GoogleLogin from 'pages/Login/SignIn/googleLogin/GoogleRedirect';
+import AdminSignIn from 'pages/Admin/components/AdminLogin/AdminLogin';
 
 const Router = () => {
   return (
@@ -19,6 +20,7 @@ const Router = () => {
         <Route path="/noticeboard" element={<NoticeBoard />} />
         <Route path="/*" element={<MainRouter />} />
         <Route path="/admin/:value/*" element={<Admin />} />
+        <Route path="/adminsignin" element={<AdminSignIn />} />
         <Route path="/chat" element={<ChatRoom />} />
         <Route path="/kakaoLogin" element={<KakaoLogin />} />
         <Route path="/googleLogin" element={<GoogleLogin />} />

--- a/src/pages/Admin/components/AdminContainer.tsx
+++ b/src/pages/Admin/components/AdminContainer.tsx
@@ -18,11 +18,25 @@ const AdminContainer = () => {
   const [postData, setPostData] = useState();
   const [loading, setLoading] = useState(false);
 
+  const [currentPage, setCurrentPage] = useState(1);
+  const [counts, setCounts] = useState();
+  // const LIMIT = 10;
+  // const [pageNum, setPageNum] = useState({ limit: LIMIT, offset: 0 });
+  // const updatePageNum = (buttonNumber: number) => {
+  //   setPageNum({
+  //     ...pageNum,
+  //     limit: LIMIT,
+  //     offset: buttonNumber * LIMIT - LIMIT,
+  //   });
+  // };
+
   const fetchData = async () => {
     try {
       setLoading(true);
       const response = await axios.get(
-        `https://togedog-dj.herokuapp.com/${location.pathname.slice(7)}`,
+        `https://togedog-dj.herokuapp.com/${location.pathname.slice(
+          7
+        )}?page=${currentPage}`,
         {
           headers: {
             accept: '*/*',
@@ -30,7 +44,8 @@ const AdminContainer = () => {
           },
         }
       );
-      setPostData(response.data);
+      setPostData(response.data.items);
+      setCounts(response.data.count);
     } finally {
       setLoading(false);
     }
@@ -38,7 +53,7 @@ const AdminContainer = () => {
 
   useEffect(() => {
     fetchData();
-  }, [location.pathname]);
+  }, [location.pathname, currentPage]);
 
   const setClick = list => {
     setClicked(list.value);
@@ -65,26 +80,34 @@ const AdminContainer = () => {
           {params.value === 'users' ? (
             <AdminRightPageUser
               postData={postData}
-              setPostData={setPostData}
               loading={loading}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+              counts={counts}
             />
           ) : params.value === 'posts' ? (
             <AdminRightPagePost
               postData={postData}
-              setPostData={setPostData}
               loading={loading}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+              counts={counts}
             />
           ) : params.value === 'posts' ? (
             <AdminRightPagePost
               postData={postData}
-              setPostData={setPostData}
               loading={loading}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+              counts={counts}
             />
           ) : (
             <AdminRightPageUser
               postData={postData}
-              setPostData={setPostData}
               loading={loading}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+              counts={counts}
             />
           )}
         </AdminRightSection>

--- a/src/pages/Admin/components/AdminContainer.tsx
+++ b/src/pages/Admin/components/AdminContainer.tsx
@@ -20,15 +20,6 @@ const AdminContainer = () => {
 
   const [currentPage, setCurrentPage] = useState(1);
   const [counts, setCounts] = useState();
-  // const LIMIT = 10;
-  // const [pageNum, setPageNum] = useState({ limit: LIMIT, offset: 0 });
-  // const updatePageNum = (buttonNumber: number) => {
-  //   setPageNum({
-  //     ...pageNum,
-  //     limit: LIMIT,
-  //     offset: buttonNumber * LIMIT - LIMIT,
-  //   });
-  // };
 
   const fetchData = async () => {
     try {

--- a/src/pages/Admin/components/AdminLogin/AdminInputForm.tsx
+++ b/src/pages/Admin/components/AdminLogin/AdminInputForm.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const AdminInputForm = ({ placeholder, type }) => {
+  return <AdminInput placeholder={placeholder} type={type} />;
+};
+const AdminInput = styled.input`
+  width: 22rem;
+  height: 1.875rem;
+  margin-bottom: 2.5rem;
+  padding-left: 0;
+  border: none;
+  border-bottom: 1px solid darkgray;
+  font-size: 1.063rem;
+`;
+export default AdminInputForm;

--- a/src/pages/Admin/components/AdminLogin/AdminLogin.tsx
+++ b/src/pages/Admin/components/AdminLogin/AdminLogin.tsx
@@ -1,0 +1,101 @@
+import styled from 'styled-components';
+import axios from 'axios';
+import { useState } from 'react';
+import signInbg from 'assets/images/bg1.jpg';
+import AdminLoginButton from 'pages/Admin/components/AdminLogin/AdminLoginButton';
+import character from 'assets/images/LoginBgCharacter.png';
+
+const AdminSignIn = () => {
+  const [adminId, setAdminId] = useState('');
+  const [adminPassword, setAdminPassword] = useState('');
+
+  const loginPost = e => {
+    e.preventDefault();
+    axios
+      .post('url', {
+        id: adminId,
+        password: adminPassword,
+      })
+      .then(res => console.log(res.data));
+  };
+
+  return (
+    <SignInContainer>
+      <Character src={character} />
+      <LoginForm>
+        <LoginTitle>관리자 로그인</LoginTitle>
+        <LoginSubTitle>관리하러 가시개!</LoginSubTitle>
+        <IdPwInputContainer onSubmit={e => loginPost(e)}>
+          <AdminIdInput
+            placeholder="아이디 입력"
+            type="text"
+            onChange={e => setAdminId(e.target.value)}
+          />
+          <AdminPasswordInput
+            placeholder="비밀번호 입력"
+            type="password"
+            onChange={e => setAdminPassword(e.target.value)}
+          />
+        </IdPwInputContainer>
+        <AdminLoginButton
+          title="로그인"
+          color="#728180"
+          size={21}
+          loginPost={loginPost}
+        />
+      </LoginForm>
+    </SignInContainer>
+  );
+};
+const SignInContainer = styled.div`
+  ${props => props.theme.flex.flexBox('flex', 'center', 'space-around')}
+  height: 100vh;
+  background-image: url(${signInbg});
+  background-size: cover;
+  background-repeat: no-repeat;
+`;
+const Character = styled.img`
+  height: 34.375rem;
+`;
+const LoginForm = styled.div`
+  ${props => props.theme.flex.flexBox('column', 'center', 'center')}
+  max-width: 40rem;
+  height: 40rem;
+  padding: 3.5rem;
+  border-radius: 1.25rem;
+  background-color: white;
+  box-shadow: 1px 2px 3px 4px lightgray;
+`;
+const LoginTitle = styled.div`
+  font-size: 3rem;
+  font-weight: 700;
+`;
+const LoginSubTitle = styled.div`
+  margin-top: 1.25rem;
+  font-size: 1.2rem;
+  color: ${props => props.theme.colors.darkGray};
+`;
+const IdPwInputContainer = styled.form`
+  margin-top: 4.6rem;
+`;
+
+const AdminIdInput = styled.input`
+  width: 22rem;
+  height: 1.875rem;
+  margin-bottom: 2.5rem;
+  padding-left: 0;
+  border: none;
+  border-bottom: 1px solid darkgray;
+  font-size: 1.063rem;
+`;
+
+const AdminPasswordInput = styled.input`
+  width: 22rem;
+  height: 1.875rem;
+  margin-bottom: 2.5rem;
+  padding-left: 0;
+  border: none;
+  border-bottom: 1px solid darkgray;
+  font-size: 1.063rem;
+`;
+export default AdminSignIn;

--- a/src/pages/Admin/components/AdminLogin/AdminLoginButton.tsx
+++ b/src/pages/Admin/components/AdminLogin/AdminLoginButton.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+const LoginButton = ({ title, color, size, loginPost }) => {
+  return (
+    <Button
+      color={color}
+      style={{ width: `${size}rem` }}
+      onClick={e => loginPost(e)}
+    >
+      {title}
+    </Button>
+  );
+};
+const Button = styled.button`
+  display: block;
+  margin-bottom: 1.25rem;
+  padding: 0.6rem 0;
+  border: none;
+  border-radius: 0.625rem;
+  background-color: ${({ color }) => color};
+  color: white;
+  text-align: center;
+  font-size: 1.25rem;
+`;
+export default LoginButton;

--- a/src/pages/Admin/components/PageNation.tsx
+++ b/src/pages/Admin/components/PageNation.tsx
@@ -1,38 +1,104 @@
 import styled from 'styled-components';
+import {
+  BiArrowFromLeft,
+  BiArrowFromRight,
+  BiLeftArrowAlt,
+  BiRightArrowAlt,
+} from 'react-icons/bi';
 
 const PageNation = ({
   perPage,
-  totalPost,
   setCurrentPage,
-  indexClicked,
-  setIndexClicked,
+  currentPage,
+  blockNum,
+  setBlockNum,
+  counts,
 }: any) => {
-  const pageNumbers: number[] = [];
-  for (let i = 1; i <= Math.ceil(totalPost / perPage); i++) {
-    pageNumbers.push(i);
-  }
+  const createArr = (n: number) => {
+    const iArr: number[] = new Array(n);
+    for (let i = 0; i < n; i++) iArr[i] = i + 1;
+    return iArr;
+  };
+
+  const pageLimit = 10;
+  const totalPage: number = Math.ceil(counts / perPage);
+  const blockArea: number = Number(blockNum * pageLimit);
+  const nArr = createArr(Number(totalPage));
+  let pArr = nArr?.slice(blockArea, Number(pageLimit) + blockArea);
+
+  const firstPage = () => {
+    setCurrentPage(1);
+    setBlockNum(0);
+  };
+
+  const lastPage = () => {
+    setCurrentPage(totalPage);
+    setBlockNum(Math.ceil(totalPage / pageLimit) - 1);
+  };
+
+  const prevPage = () => {
+    if (currentPage <= 1) {
+      return;
+    }
+    if (currentPage - 1 <= pageLimit * blockNum) {
+      setBlockNum((n: number) => n - 1);
+    }
+    setCurrentPage((n: number) => n - 1);
+  };
+
+  const nextPage = () => {
+    if (currentPage >= totalPage) {
+      return;
+    }
+    if (pageLimit * Number(blockNum + 1) < Number(currentPage + 1)) {
+      setBlockNum((n: number) => n + 1);
+    }
+    setCurrentPage((n: number) => n + 1);
+  };
+
   return (
     <PageUl>
-      {pageNumbers.map(number => (
-        <PageLi
-          key={number}
-          className={number === indexClicked ? 'indexClicked' : ' '}
-        >
+      <BiArrowFromRight
+        onClick={() => {
+          firstPage();
+        }}
+        className="moveToFirst"
+      />
+      <BiLeftArrowAlt
+        onClick={() => {
+          prevPage();
+        }}
+        className="moveToPrev"
+      />
+      {pArr.map((n: number) => (
+        <PageLi key={n} className={n === currentPage ? 'clicked' : ' '}>
           <PageSpan
             onClick={() => {
-              setCurrentPage(number);
-              setIndexClicked(number);
+              setCurrentPage(n);
             }}
           >
-            {number}
+            {n}
           </PageSpan>
         </PageLi>
       ))}
+      <BiRightArrowAlt
+        onClick={() => {
+          nextPage();
+        }}
+        className="moveToNext"
+      />
+      <BiArrowFromLeft
+        onClick={() => {
+          lastPage();
+        }}
+        className="moveToLast"
+      />
     </PageUl>
   );
 };
 
 const PageUl = styled.ul`
+  ${props => props.theme.flex.flexBox('', 'center', 'center')};
   margin-top: 0.5rem;
   margin-left: auto;
   margin-right: auto;
@@ -40,6 +106,23 @@ const PageUl = styled.ul`
   float: left;
   list-style: none;
   text-align: center;
+
+  .moveToFirst,
+  .moveToPrev,
+  .moveToNext,
+  .moveToLast {
+    cursor: pointer;
+  }
+
+  .moveToFirst,
+  .moveToPrev {
+    margin-right: 0.5rem;
+  }
+
+  .moveToLast,
+  .moveToNext {
+    margin-left: 0.5rem;
+  }
 `;
 
 const PageLi = styled.li`
@@ -50,7 +133,7 @@ const PageLi = styled.li`
   border-radius: 0.313rem;
   width: 1.5rem;
 
-  &.indexClicked {
+  &.clicked {
     color: white;
     background-color: ${props => props.theme.colors.gray};
   }

--- a/src/pages/Admin/components/RightSection/AdminRightPagePost.tsx
+++ b/src/pages/Admin/components/RightSection/AdminRightPagePost.tsx
@@ -22,20 +22,8 @@ const AdminRightPagePost = ({
   const [modalId, setModalId] = useState<number | undefined>();
   const [allToggle, setAllToggle] = useState<boolean>(false);
   const [banToggle, setBanToggle] = useState<boolean>(false);
-  // const [search, setSearch] = useState<string>('');
-  // const [pagenatedData, setPagenatedData] = useState(postData);
-
   const [blockNum, setBlockNum] = useState(0);
   const perPage = 10;
-
-  // const indexOfLast = currentPage * perPage;
-  // const indexOfFirst = indexOfLast - perPage;
-
-  // useEffect(() => {
-  //   if (postData) {
-  //     setPagenatedData(postData.slice(indexOfFirst, indexOfLast));
-  //   }
-  // }, [postData, indexOfFirst, indexOfLast]);
 
   const openModal = (): void => {
     setIsModalOpen(true);
@@ -48,36 +36,6 @@ const AdminRightPagePost = ({
   const onCurrentModal = id => {
     setModalId(id);
   };
-
-  // const onChangeSearch = e => {
-  //   e.preventDefault();
-  //   setSearch(e.target.value);
-  // };
-
-  // const onSearch = e => {
-  //   e.preventDefault();
-  //   if (search === null || search === '') {
-  //     axios
-  //       .get(`https://togedog-dj.herokuapp.com/${location.pathname.slice(7)}`, {
-  //         headers: {
-  //           accept: '*/*',
-  //           Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDY4NTQ5MiwiaWF0IjoxNjYyMDkzNDkyfQ.AQAciBT2VhdUDY-rQuoRiJCXE3BfIQJd95KgCXk0eKU`,
-  //         },
-  //       })
-  //       .then(res => {
-  //         setPostData(res.data);
-  //         setPagenatedData(res.data.slice(indexOfFirst, indexOfLast));
-  //       });
-  //   } else {
-  //     const filterData = pagenatedData.filter(data =>
-  //       data.user_nickname.includes(search)
-  //     );
-  //     setPostData(filterData);
-  //     setPagenatedData(filterData.slice(indexOfFirst, indexOfLast));
-  //     setCurrentPage(1);
-  //   }
-  //   setSearch('');
-  // };
 
   return (
     <AdminRightContainer>

--- a/src/pages/Admin/components/RightSection/AdminRightPagePost.tsx
+++ b/src/pages/Admin/components/RightSection/AdminRightPagePost.tsx
@@ -1,6 +1,5 @@
-import axios from 'axios';
 import styled from 'styled-components';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import PostHeaderBox from 'pages/Admin/components/RightSection/PostHeaderBox';
 import DeletedPostModal from 'pages/Admin/components/Modal/DeletedPostModal';
@@ -10,26 +9,33 @@ import DatePickerComponent from 'pages/Admin/components/DatePickerComponent';
 import PageNation from 'pages/Admin/components/PageNation';
 import AdminSpinner from 'pages/Admin/components/AdminSpinner.tsx/AdminSpinner';
 
-const AdminRightPagePost = ({ postData, setPostData, loading }) => {
+const AdminRightPagePost = ({
+  postData,
+  loading,
+  currentPage,
+  setCurrentPage,
+  counts,
+}) => {
   const location = useLocation();
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [modalId, setModalId] = useState<number | undefined>();
   const [allToggle, setAllToggle] = useState<boolean>(false);
   const [banToggle, setBanToggle] = useState<boolean>(false);
-  const [search, setSearch] = useState<string>('');
-  const [currentPage, setCurrentPage] = useState(1);
-  const [indexClicked, setIndexClicked] = useState('');
-  const [pagenatedData, setPagenatedData] = useState(postData);
-  const perPage = 10;
-  const indexOfLast = currentPage * perPage;
-  const indexOfFirst = indexOfLast - perPage;
+  // const [search, setSearch] = useState<string>('');
+  // const [pagenatedData, setPagenatedData] = useState(postData);
 
-  useEffect(() => {
-    if (postData) {
-      setPagenatedData(postData.slice(indexOfFirst, indexOfLast));
-    }
-  }, [postData, indexOfFirst, indexOfLast]);
+  const [blockNum, setBlockNum] = useState(0);
+  const perPage = 10;
+
+  // const indexOfLast = currentPage * perPage;
+  // const indexOfFirst = indexOfLast - perPage;
+
+  // useEffect(() => {
+  //   if (postData) {
+  //     setPagenatedData(postData.slice(indexOfFirst, indexOfLast));
+  //   }
+  // }, [postData, indexOfFirst, indexOfLast]);
 
   const openModal = (): void => {
     setIsModalOpen(true);
@@ -43,35 +49,35 @@ const AdminRightPagePost = ({ postData, setPostData, loading }) => {
     setModalId(id);
   };
 
-  const onChangeSearch = e => {
-    e.preventDefault();
-    setSearch(e.target.value);
-  };
+  // const onChangeSearch = e => {
+  //   e.preventDefault();
+  //   setSearch(e.target.value);
+  // };
 
-  const onSearch = e => {
-    e.preventDefault();
-    if (search === null || search === '') {
-      axios
-        .get(`https://togedog-dj.herokuapp.com/${location.pathname.slice(7)}`, {
-          headers: {
-            accept: '*/*',
-            Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDY4NTQ5MiwiaWF0IjoxNjYyMDkzNDkyfQ.AQAciBT2VhdUDY-rQuoRiJCXE3BfIQJd95KgCXk0eKU`,
-          },
-        })
-        .then(res => {
-          setPostData(res.data);
-          setPagenatedData(res.data.slice(indexOfFirst, indexOfLast));
-        });
-    } else {
-      const filterData = pagenatedData.filter(data =>
-        data.user_nickname.includes(search)
-      );
-      setPostData(filterData);
-      setPagenatedData(filterData.slice(indexOfFirst, indexOfLast));
-      setCurrentPage(1);
-    }
-    setSearch('');
-  };
+  // const onSearch = e => {
+  //   e.preventDefault();
+  //   if (search === null || search === '') {
+  //     axios
+  //       .get(`https://togedog-dj.herokuapp.com/${location.pathname.slice(7)}`, {
+  //         headers: {
+  //           accept: '*/*',
+  //           Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDY4NTQ5MiwiaWF0IjoxNjYyMDkzNDkyfQ.AQAciBT2VhdUDY-rQuoRiJCXE3BfIQJd95KgCXk0eKU`,
+  //         },
+  //       })
+  //       .then(res => {
+  //         setPostData(res.data);
+  //         setPagenatedData(res.data.slice(indexOfFirst, indexOfLast));
+  //       });
+  //   } else {
+  //     const filterData = pagenatedData.filter(data =>
+  //       data.user_nickname.includes(search)
+  //     );
+  //     setPostData(filterData);
+  //     setPagenatedData(filterData.slice(indexOfFirst, indexOfLast));
+  //     setCurrentPage(1);
+  //   }
+  //   setSearch('');
+  // };
 
   return (
     <AdminRightContainer>
@@ -97,22 +103,22 @@ const AdminRightPagePost = ({ postData, setPostData, loading }) => {
             <DatePickerComponent />
           </DateFilter>
         </SortByDate>
-        <SortByUser onSubmit={e => onSearch(e)}>
+        <SortByUser>
           <UserTitle>
             <TitleText>사용자 검색</TitleText>
           </UserTitle>
-          <UserInput type="text" value={search} onChange={onChangeSearch} />
+          <UserInput type="text" />
         </SortByUser>
       </SortBox>
       <UserListContainer>
         {loading ? (
           <AdminSpinner />
         ) : (
-          pagenatedData && (
+          postData && (
             <>
               <PostHeaderBox />
               <ListContentsSection>
-                {pagenatedData.map(data => (
+                {postData.map(data => (
                   <ListPostContentsBox
                     data={data}
                     key={data.id}
@@ -122,10 +128,11 @@ const AdminRightPagePost = ({ postData, setPostData, loading }) => {
                 ))}
                 <PageNation
                   perPage={perPage}
-                  totalPost={postData.length}
                   setCurrentPage={setCurrentPage}
-                  setIndexClicked={setIndexClicked}
-                  indexClicked={indexClicked}
+                  currentPage={currentPage}
+                  blockNum={blockNum}
+                  setBlockNum={setBlockNum}
+                  counts={counts}
                 />
                 {isModalOpen &&
                   (location.pathname === '/admin/posts' ? (

--- a/src/pages/Admin/components/RightSection/AdminRightPageUser.tsx
+++ b/src/pages/Admin/components/RightSection/AdminRightPageUser.tsx
@@ -18,19 +18,8 @@ const AdminRightPageUser = ({
   const [modalId, setModalId] = useState<number | undefined>();
   const [allToggle, setAllToggle] = useState(false);
   const [banToggle, setBanToggle] = useState(false);
-  // const [search, setSearch] = useState<string>('');
-  // const [pagenatedData, setPagenatedData] = useState(postData);
-
   const [blockNum, setBlockNum] = useState(0);
   const perPage = 10;
-  // const indexOfLast = currentPage * perPage;
-  // const indexOfFirst = indexOfLast - perPage;
-
-  // useEffect(() => {
-  //   if (postData) {
-  //     setPagenatedData(postData.slice(indexOfFirst, indexOfLast));
-  //   }
-  // }, [postData, indexOfFirst, indexOfLast]);
 
   const openModal = (): void => {
     setIsModalOpen(true);
@@ -43,36 +32,6 @@ const AdminRightPageUser = ({
   const onCurrentModal = id => {
     setModalId(id);
   };
-
-  // const onChangeSearch = e => {
-  //   e.preventDefault();
-  //   setSearch(e.target.value);
-  // };
-
-  // const onSearch = e => {
-  //   e.preventDefault();
-  //   if (search === null || search === '') {
-  //     axios
-  //       .get(`https://togedog-dj.herokuapp.com/${location.pathname.slice(7)}`, {
-  //         headers: {
-  //           accept: '*/*',
-  //           Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDY4NTQ5MiwiaWF0IjoxNjYyMDkzNDkyfQ.AQAciBT2VhdUDY-rQuoRiJCXE3BfIQJd95KgCXk0eKU`,
-  //         },
-  //       })
-  //       .then(res => {
-  //         setPostData(res.data);
-  //         setPagenatedData(res.data.slice(indexOfFirst, indexOfLast));
-  //       });
-  //   } else {
-  //     const filterData = pagenatedData.filter(data =>
-  //       data.name.includes(search)
-  //     );
-  //     setPostData(filterData);
-  //     setPagenatedData(filterData.slice(indexOfFirst, indexOfLast));
-  //     setCurrentPage(1);
-  //   }
-  //   setSearch('');
-  // };
 
   return (
     <AdminRightContainer>

--- a/src/pages/Admin/components/RightSection/AdminRightPageUser.tsx
+++ b/src/pages/Admin/components/RightSection/AdminRightPageUser.tsx
@@ -1,7 +1,5 @@
-import axios from 'axios';
 import styled from 'styled-components';
-import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useState } from 'react';
 import ListHeaderBox from 'pages/Admin/components/RightSection/ListHeaderBox';
 import ListContentsBox from 'pages/Admin/components/RightSection/ListContentsBox';
 import UserModal from 'pages/Admin/components/Modal/UserModal';
@@ -9,26 +7,30 @@ import DatePickerComponent from 'pages/Admin/components/DatePickerComponent';
 import PageNation from 'pages/Admin/components/PageNation';
 import AdminSpinner from 'pages/Admin/components/AdminSpinner.tsx/AdminSpinner';
 
-const AdminRightPageUser = ({ postData, setPostData, loading }) => {
-  const location = useLocation();
-
+const AdminRightPageUser = ({
+  postData,
+  loading,
+  currentPage,
+  setCurrentPage,
+  counts,
+}) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalId, setModalId] = useState<number | undefined>();
   const [allToggle, setAllToggle] = useState(false);
   const [banToggle, setBanToggle] = useState(false);
-  const [search, setSearch] = useState<string>('');
-  const [currentPage, setCurrentPage] = useState(1);
-  const [indexClicked, setIndexClicked] = useState('');
-  const [pagenatedData, setPagenatedData] = useState(postData);
-  const perPage = 10;
-  const indexOfLast = currentPage * perPage;
-  const indexOfFirst = indexOfLast - perPage;
+  // const [search, setSearch] = useState<string>('');
+  // const [pagenatedData, setPagenatedData] = useState(postData);
 
-  useEffect(() => {
-    if (postData) {
-      setPagenatedData(postData.slice(indexOfFirst, indexOfLast));
-    }
-  }, [postData, indexOfFirst, indexOfLast]);
+  const [blockNum, setBlockNum] = useState(0);
+  const perPage = 10;
+  // const indexOfLast = currentPage * perPage;
+  // const indexOfFirst = indexOfLast - perPage;
+
+  // useEffect(() => {
+  //   if (postData) {
+  //     setPagenatedData(postData.slice(indexOfFirst, indexOfLast));
+  //   }
+  // }, [postData, indexOfFirst, indexOfLast]);
 
   const openModal = (): void => {
     setIsModalOpen(true);
@@ -42,35 +44,35 @@ const AdminRightPageUser = ({ postData, setPostData, loading }) => {
     setModalId(id);
   };
 
-  const onChangeSearch = e => {
-    e.preventDefault();
-    setSearch(e.target.value);
-  };
+  // const onChangeSearch = e => {
+  //   e.preventDefault();
+  //   setSearch(e.target.value);
+  // };
 
-  const onSearch = e => {
-    e.preventDefault();
-    if (search === null || search === '') {
-      axios
-        .get(`https://togedog-dj.herokuapp.com/${location.pathname.slice(7)}`, {
-          headers: {
-            accept: '*/*',
-            Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDY4NTQ5MiwiaWF0IjoxNjYyMDkzNDkyfQ.AQAciBT2VhdUDY-rQuoRiJCXE3BfIQJd95KgCXk0eKU`,
-          },
-        })
-        .then(res => {
-          setPostData(res.data);
-          setPagenatedData(res.data.slice(indexOfFirst, indexOfLast));
-        });
-    } else {
-      const filterData = pagenatedData.filter(data =>
-        data.name.includes(search)
-      );
-      setPostData(filterData);
-      setPagenatedData(filterData.slice(indexOfFirst, indexOfLast));
-      setCurrentPage(1);
-    }
-    setSearch('');
-  };
+  // const onSearch = e => {
+  //   e.preventDefault();
+  //   if (search === null || search === '') {
+  //     axios
+  //       .get(`https://togedog-dj.herokuapp.com/${location.pathname.slice(7)}`, {
+  //         headers: {
+  //           accept: '*/*',
+  //           Authorization: `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjo5LCJ1c2VyX3R5cGUiOiJhZG1pbiIsImV4cCI6MTY2NDY4NTQ5MiwiaWF0IjoxNjYyMDkzNDkyfQ.AQAciBT2VhdUDY-rQuoRiJCXE3BfIQJd95KgCXk0eKU`,
+  //         },
+  //       })
+  //       .then(res => {
+  //         setPostData(res.data);
+  //         setPagenatedData(res.data.slice(indexOfFirst, indexOfLast));
+  //       });
+  //   } else {
+  //     const filterData = pagenatedData.filter(data =>
+  //       data.name.includes(search)
+  //     );
+  //     setPostData(filterData);
+  //     setPagenatedData(filterData.slice(indexOfFirst, indexOfLast));
+  //     setCurrentPage(1);
+  //   }
+  //   setSearch('');
+  // };
 
   return (
     <AdminRightContainer>
@@ -96,22 +98,22 @@ const AdminRightPageUser = ({ postData, setPostData, loading }) => {
             <DatePickerComponent />
           </DateFilter>
         </SortByDate>
-        <SortByUser onSubmit={e => onSearch(e)}>
+        <SortByUser>
           <UserTitle>
             <TitleText>사용자 검색</TitleText>
           </UserTitle>
-          <UserInput type="text" value={search} onChange={onChangeSearch} />
+          <UserInput type="text" />
         </SortByUser>
       </SortBox>
       <UserListContainer>
         {loading ? (
           <AdminSpinner />
         ) : (
-          pagenatedData && (
+          postData && (
             <>
               <ListHeaderBox />
               <ListContentsSection>
-                {pagenatedData.map(data => (
+                {postData.map(data => (
                   <ListContentsBox
                     data={data}
                     key={data.id}
@@ -121,10 +123,11 @@ const AdminRightPageUser = ({ postData, setPostData, loading }) => {
                 ))}
                 <PageNation
                   perPage={perPage}
-                  totalPost={postData.length}
                   setCurrentPage={setCurrentPage}
-                  setIndexClicked={setIndexClicked}
-                  indexClicked={indexClicked}
+                  currentPage={currentPage}
+                  blockNum={blockNum}
+                  setBlockNum={setBlockNum}
+                  counts={counts}
                 />
                 {isModalOpen && (
                   <UserModal closeModal={closeModal} modalId={modalId} />


### PR DESCRIPTION
### :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

### :: 구현 목표 
- 기존 페이지네이션을 프론트단에서 처리하던 방식을, 데이터의 효율을 위해 백엔드에 요청하는 형태로 페이지네이션을 수정
- 어드민 로그인 ui 추가
<br />

### :: 구현 사항
- 프론트에서 처리하던 형태의 검색 및 페이지네이션 삭제 후 페이지네이션의 로직 먼저 수정.
- 페이지네이션의 페이지 넘버를 데이터 수의 맞춰서 구현하고 10페이지가 넘어가면 먼저 안 보이다가, 11페이지부터 20페이지가 보일 수 있도록 페이징 처리
- 페이지 버튼과 함께 옆으로 넘어가는 화살표에 맞춰서도 페이지 이동 가능(첫페이지 및 마지막 페이지로 한 번에 이동도 가능)
<br />

### :: 특이 사항
- 검색 기능은 삭제되었으며, 추후 다중 필터와 함께 검색 기능 추가 예정.(백엔드 통하는 방식으로)
- 컨벤션에 따른 주석제거 