### PR TITLE
[경연] MBTI 테스트 페이지_FN_Login

### DIFF
--- a/src/pages/MBTI/MBTIResult/Graph/MBTIGraph.tsx
+++ b/src/pages/MBTI/MBTIResult/Graph/MBTIGraph.tsx
@@ -1,11 +1,10 @@
 import styled from 'styled-components/macro';
 import GraphComponent from './GraphComponent';
-import { MBTI_RESULT_DATA } from '../constants/Result';
 
-const MBTIGraph = () => {
+const MBTIGraph = ({ graphResult }) => {
   return (
     <MBTIGraphContainer>
-      {MBTI_RESULT_DATA.map(({ mbti, score, id, layout }) => (
+      {graphResult[1].map(({ mbti, score, id, layout }) => (
         <GraphComponent key={id} mbti={mbti} score={score} layout={layout} />
       ))}
     </MBTIGraphContainer>

--- a/src/pages/MBTI/MBTIResult/Graph/MBTIGraph.tsx
+++ b/src/pages/MBTI/MBTIResult/Graph/MBTIGraph.tsx
@@ -4,7 +4,7 @@ import GraphComponent from './GraphComponent';
 const MBTIGraph = ({ graphResult }) => {
   return (
     <MBTIGraphContainer>
-      {graphResult[1].map(({ mbti, score, id, layout }) => (
+      {graphResult.map(({ mbti, score, id, layout }) => (
         <GraphComponent key={id} mbti={mbti} score={score} layout={layout} />
       ))}
     </MBTIGraphContainer>

--- a/src/pages/MBTI/MBTIResult/MBTIResult.tsx
+++ b/src/pages/MBTI/MBTIResult/MBTIResult.tsx
@@ -7,6 +7,8 @@ import { RootState } from 'redux/reducers';
 const MBTIResult = () => {
   const graphResult = useSelector((state: RootState) => state.graph);
   const mbtiResultText = useSelector((state: RootState) => state.mbtiText);
+  const checkLogin = useSelector((state: RootState) => state.user);
+  console.log(checkLogin);
 
   return (
     <MBTIResultContainer>

--- a/src/pages/MBTI/MBTIResult/MBTIResult.tsx
+++ b/src/pages/MBTI/MBTIResult/MBTIResult.tsx
@@ -5,11 +5,16 @@ import { useSelector } from 'react-redux';
 import { RootState } from 'redux/reducers';
 
 const MBTIResult = () => {
-  const exampleSelector = useSelector((state: RootState) => state.graph);
+  const graphResult = useSelector((state: RootState) => state.graph);
+  const mbtiResultText = useSelector((state: RootState) => state.mbtiText);
+
   return (
     <MBTIResultContainer>
       <MBTIResultBox>
-        <MBTIResultInfo />
+        <MBTIResultInfo
+          graphResult={graphResult}
+          mbtiResultText={mbtiResultText}
+        />
       </MBTIResultBox>
     </MBTIResultContainer>
   );

--- a/src/pages/MBTI/MBTIResult/MBTIResult.tsx
+++ b/src/pages/MBTI/MBTIResult/MBTIResult.tsx
@@ -8,7 +8,6 @@ const MBTIResult = () => {
   const graphResult = useSelector((state: RootState) => state.graph);
   const mbtiResultText = useSelector((state: RootState) => state.mbtiText);
   const checkLogin = useSelector((state: RootState) => state.user);
-  console.log(checkLogin);
 
   return (
     <MBTIResultContainer>

--- a/src/pages/MBTI/MBTIResult/MBTIResultInfo.tsx
+++ b/src/pages/MBTI/MBTIResult/MBTIResultInfo.tsx
@@ -2,32 +2,38 @@ import styled, { css } from 'styled-components/macro';
 import MBTIGraph from './Graph/MBTIGraph';
 import ChatroomRecommendation from './ChatroomRecommendation';
 import SNSshare from './SNSshare';
-import ESFC_DOG from 'assets/svg/ESFC_DOG.svg';
 import ResultInfo from 'assets/svg/ResultInfoPositoin.svg';
 import ResultNotice from 'assets/svg/ResultNoticePositoin.svg';
-import ESFCPosition from 'assets/svg/ESFCPositoin.svg';
 import { MBTI_RESULT } from './constants/Result';
 
 const MBTIResultInfo = ({ graphResult, mbtiResultText }) => {
-  const findMBTIValue = mbtiResultText.mbti;
-  const getMBTIResult = Object.values(findMBTIValue);
+  // const findMBTIValue = mbtiResultText.mbti;
+  const getMBTIResult: string = Object.values(mbtiResultText.mbti).toString();
+  const resultMBTI = MBTI_RESULT.filter(item => {
+    return item.MBTI === getMBTIResult;
+  });
+  console.log(resultMBTI);
 
   return (
     <MBTIResultInfoContainer>
-      <MBTIDOG src={ESFC_DOG} />
-      <MBTIResult>ESFC</MBTIResult>
-      <MBTICharacter>천진난만 꾸러기 댕댕이</MBTICharacter>
-      <MBTIContent>
-        에너지가 넘치는 꾸러기 댕댕이군요! 에너지를 분출시켜주기 위해서 자주
-        산책을 시켜주는 것이 좋을 것 같아요! 다른 강아지한테 장난도 많고
-        나한테도 장난을 많이 치는 성격인데 확실히 교육과 놀이를 구분시켜 가르칠
-        필요가 있습니다! 흥분을 절제하는 방법을 교육 시키는 것 또한
-        좋아보입니다!
-      </MBTIContent>
-      <NoticeImage src={ResultNotice} />
-      <GraphInfo src={ResultInfo} />
-      <MBTIGraph graphResult={graphResult} />
-      <GraphSummary src={ESFCPosition} />
+      {resultMBTI.map(({ MBTI, MBTICharacter, MBTIImage, MBTIPosition }) => (
+        <>
+          <MBTIDOG src={MBTIImage} />
+          <MBTIResult>{MBTI}</MBTIResult>
+          <MBTICharacterText>{MBTICharacter}</MBTICharacterText>
+          <MBTIContent>
+            에너지가 넘치는 꾸러기 댕댕이군요! 에너지를 분출시켜주기 위해서 자주
+            산책을 시켜주는 것이 좋을 것 같아요! 다른 강아지한테 장난도 많고
+            나한테도 장난을 많이 치는 성격인데 확실히 교육과 놀이를 구분시켜
+            가르칠 필요가 있습니다! 흥분을 절제하는 방법을 교육 시키는 것 또한
+            좋아보입니다!
+          </MBTIContent>
+          <NoticeImage src={ResultNotice} />
+          <GraphInfo src={ResultInfo} />
+          <MBTIGraph graphResult={graphResult} />
+          <GraphSummary src={MBTIPosition} />
+        </>
+      ))}
       <ChatroomRecommendation />
       <SNSshare />
     </MBTIResultInfoContainer>
@@ -45,7 +51,7 @@ const MBTIResultInfoContainer = styled.div`
 `;
 
 const MBTIDOG = styled.img`
-  width: 31.25rem;
+  width: 20rem;
 `;
 
 const MBTIResult = styled.span`
@@ -55,7 +61,7 @@ const MBTIResult = styled.span`
   ${BasicText}
 `;
 
-const MBTICharacter = styled.span`
+const MBTICharacterText = styled.span`
   margin-top: 1rem;
   font-size: 1.125rem;
   ${BasicText}

--- a/src/pages/MBTI/MBTIResult/MBTIResultInfo.tsx
+++ b/src/pages/MBTI/MBTIResult/MBTIResultInfo.tsx
@@ -7,12 +7,10 @@ import ResultNotice from 'assets/svg/ResultNoticePositoin.svg';
 import { MBTI_RESULT } from './constants/Result';
 
 const MBTIResultInfo = ({ graphResult, mbtiResultText }) => {
-  // const findMBTIValue = mbtiResultText.mbti;
   const getMBTIResult: string = Object.values(mbtiResultText.mbti).toString();
   const resultMBTI = MBTI_RESULT.filter(item => {
     return item.MBTI === getMBTIResult;
   });
-  console.log(resultMBTI);
 
   return (
     <MBTIResultInfoContainer>

--- a/src/pages/MBTI/MBTIResult/MBTIResultInfo.tsx
+++ b/src/pages/MBTI/MBTIResult/MBTIResultInfo.tsx
@@ -2,12 +2,16 @@ import styled, { css } from 'styled-components/macro';
 import MBTIGraph from './Graph/MBTIGraph';
 import ChatroomRecommendation from './ChatroomRecommendation';
 import SNSshare from './SNSshare';
-import ESFC_DOG from '../../../../src/assets/svg/ESFC_DOG.svg';
-import ResultNotice from '../../../../src/assets/svg/ResultNoticePositoin.svg';
-import ResultInfo from '../../../../src/assets/svg/ResultInfoPositoin.svg';
-import ESFCPosition from '../../../../src/assets/svg/ESFCPositoin.svg';
+import ESFC_DOG from 'assets/svg/ESFC_DOG.svg';
+import ResultInfo from 'assets/svg/ResultInfoPositoin.svg';
+import ResultNotice from 'assets/svg/ResultNoticePositoin.svg';
+import ESFCPosition from 'assets/svg/ESFCPositoin.svg';
+import { MBTI_RESULT } from './constants/Result';
 
-const MBTIResultInfo = () => {
+const MBTIResultInfo = ({ graphResult, mbtiResultText }) => {
+  const findMBTIValue = mbtiResultText.mbti;
+  const getMBTIResult = Object.values(findMBTIValue);
+
   return (
     <MBTIResultInfoContainer>
       <MBTIDOG src={ESFC_DOG} />
@@ -22,7 +26,7 @@ const MBTIResultInfo = () => {
       </MBTIContent>
       <NoticeImage src={ResultNotice} />
       <GraphInfo src={ResultInfo} />
-      <MBTIGraph />
+      <MBTIGraph graphResult={graphResult} />
       <GraphSummary src={ESFCPosition} />
       <ChatroomRecommendation />
       <SNSshare />

--- a/src/pages/MBTI/MBTITest/MBTITest.tsx
+++ b/src/pages/MBTI/MBTITest/MBTITest.tsx
@@ -14,6 +14,7 @@ import setMbtiTexts from 'redux/actions/mbtiText';
 import { useNavigate } from 'react-router-dom';
 import { RootState } from 'redux/reducers';
 import { useSelector } from 'react-redux';
+import userActions from 'redux/actions/user';
 
 const MBTITest = () => {
   const [isChecked, setIsChecked] = useState(false);
@@ -157,12 +158,19 @@ const MBTITest = () => {
   const onReactionCheck = (): void => {
     setNextReactionPage(!nextReactionPage);
   };
+  const checkLogin = useSelector((state: RootState) => state.user);
+  console.log(checkLogin);
 
   const onJudgementCheck = (): void => {
     setNextJudgementPage(!nextJudgementPage);
     navigate('/mbti-result');
     dispatch(setMbtiResults(setMBTIResult));
     dispatch(setMbtiTexts(mbtiObj));
+    {
+      checkLogin.LoggedIn === true
+        ? dispatch(userActions.setMBTI(mbtiObj))
+        : dispatch(setMbtiTexts(mbtiObj));
+    }
   };
 
   const handleSetEnergyName = (value: string, id: number): void => {

--- a/src/pages/MBTI/MBTITest/MBTITest.tsx
+++ b/src/pages/MBTI/MBTITest/MBTITest.tsx
@@ -141,7 +141,6 @@ const MBTITest = () => {
 
   const mbtiObj = {};
   const joinMbtiText = setMBTIResult.map(obj => obj.mbti).join('');
-  console.log(joinMbtiText);
   mbtiObj['mbti'] = joinMbtiText;
   const mbtiUserData = Object.values(mbtiObj).toString();
 
@@ -161,7 +160,6 @@ const MBTITest = () => {
     setNextReactionPage(!nextReactionPage);
   };
   const checkLogin = useSelector((state: RootState) => state.user);
-  console.log(checkLogin);
 
   const onJudgementCheck = (): void => {
     setNextJudgementPage(!nextJudgementPage);
@@ -218,9 +216,6 @@ const MBTITest = () => {
     relationNameList.length +
     reactionNameList.length +
     judgementNameList.length;
-  // console.log({ energyNameList });
-  // console.log(energyNameList.length);
-  // console.log(typeof energyNameList);
 
   useEffect(() => {
     setMbtiText(mbtiObj);

--- a/src/pages/MBTI/MBTITest/MBTITest.tsx
+++ b/src/pages/MBTI/MBTITest/MBTITest.tsx
@@ -7,10 +7,13 @@ import ReactionTest from './Reaction/ReactionTest';
 import JudgementTest from './Judgement/JudgementTest';
 import { AnswerType } from 'types/type';
 import { MBTIScoreProps } from 'types/type';
-import { joinMBTI } from 'types/type';
+import { JoinMBTI } from 'types/type';
 import { useDispatch } from 'react-redux';
 import setMbtiResults from 'redux/actions/mbtiResult';
 import setMbtiTexts from 'redux/actions/mbtiText';
+import { useNavigate } from 'react-router-dom';
+import { RootState } from 'redux/reducers';
+import { useSelector } from 'react-redux';
 
 const MBTITest = () => {
   const [isChecked, setIsChecked] = useState(false);
@@ -23,7 +26,8 @@ const MBTITest = () => {
   const [relationNameList, setRelationNameList] = useState<AnswerType[]>([]);
   const [reactionNameList, setReactionNameList] = useState<AnswerType[]>([]);
   const [judgementNameList, setJudgementNameList] = useState<AnswerType[]>([]);
-  const [mbtiText, setMbtiText] = useState<joinMBTI>({ mbti: '' });
+  const [mbtiText, setMbtiText] = useState<JoinMBTI>({ mbti: '' });
+  const dispatch = useDispatch();
 
   const numberArr = value => {
     const newArr = [0, 0, 0, 0, 0];
@@ -51,6 +55,7 @@ const MBTITest = () => {
   const reactionAnswerResult = reactionNameList.map(a => a.answerValue);
   const judgementAnswerResult = judgementNameList.map(a => a.answerValue);
   const setMBTIResult: MBTIScoreProps[] = [];
+  const navigate = useNavigate();
 
   const setEnergy = (energyAnswerResult): void => {
     const energyScore = numberArr(energyAnswerResult);
@@ -136,13 +141,6 @@ const MBTITest = () => {
   const mbtiObj = {};
   const joinMbtiText = setMBTIResult.map(obj => obj.mbti).join('');
   mbtiObj['mbti'] = joinMbtiText;
-  useEffect(() => {
-    setMbtiText(mbtiObj);
-  }, []);
-
-  const dispatch = useDispatch();
-  dispatch(setMbtiResults(setMBTIResult));
-  dispatch(setMbtiTexts(mbtiObj));
 
   const onClickCheck = (): void => {
     setIsChecked(!isChecked);
@@ -162,6 +160,9 @@ const MBTITest = () => {
 
   const onJudgementCheck = (): void => {
     setNextJudgementPage(!nextJudgementPage);
+    navigate('/mbti-result');
+    dispatch(setMbtiResults(setMBTIResult));
+    dispatch(setMbtiTexts(mbtiObj));
   };
 
   const handleSetEnergyName = (value: string, id: number): void => {
@@ -210,6 +211,10 @@ const MBTITest = () => {
   // console.log({ energyNameList });
   // console.log(energyNameList.length);
   // console.log(typeof energyNameList);
+
+  useEffect(() => {
+    setMbtiText(mbtiObj);
+  }, []);
 
   return (
     <MBTITestContainer>

--- a/src/pages/MBTI/MBTITest/MBTITest.tsx
+++ b/src/pages/MBTI/MBTITest/MBTITest.tsx
@@ -141,7 +141,9 @@ const MBTITest = () => {
 
   const mbtiObj = {};
   const joinMbtiText = setMBTIResult.map(obj => obj.mbti).join('');
+  console.log(joinMbtiText);
   mbtiObj['mbti'] = joinMbtiText;
+  const mbtiUserData = Object.values(mbtiObj).toString();
 
   const onClickCheck = (): void => {
     setIsChecked(!isChecked);
@@ -169,7 +171,7 @@ const MBTITest = () => {
     {
       checkLogin.LoggedIn === true
         ? dispatch(userActions.setMBTI(mbtiObj))
-        : dispatch(setMbtiTexts(mbtiObj));
+        : dispatch(userActions.setMBTI(mbtiUserData));
     }
   };
 

--- a/src/redux/reducers/index.ts
+++ b/src/redux/reducers/index.ts
@@ -10,7 +10,7 @@ import mbtiTextReducer from './mbtiTextReducer';
 const persistConfig = {
   key: 'root',
   storage,
-  whitelist: ['mbtiText'],
+  whitelist: ['mbtiText', 'graph'],
 };
 
 const authPersistConfig = {

--- a/src/redux/reducers/mbtiGraphReducer.ts
+++ b/src/redux/reducers/mbtiGraphReducer.ts
@@ -3,7 +3,7 @@ const initialState = [{ id: null, mbti: '', score: null, layout: '' }];
 const mbtiGraphReducer = (prevState = initialState, action) => {
   switch (action.type) {
     case 'SET_MBTI_GRAPH':
-      return [...prevState, action.data];
+      return action.data;
     default:
       return prevState;
   }

--- a/src/redux/reducers/mbtiTextReducer.ts
+++ b/src/redux/reducers/mbtiTextReducer.ts
@@ -1,9 +1,9 @@
-const initialState = [{ mbti: '' }];
+const initialState = { mbti: '' };
 
 const mbtiTextReducer = (prevState = initialState, action) => {
   switch (action.type) {
     case 'SET_MBTI_TEXT':
-      return [...prevState, action.data];
+      return { ...prevState, mbti: action.data };
     default:
       return prevState;
   }

--- a/src/redux/reducers/userReducer.ts
+++ b/src/redux/reducers/userReducer.ts
@@ -1,7 +1,13 @@
 const initialState = {
   LoggedIn: false,
   userData: {
-    mbti: 'none',
+    account_type: '',
+    email: '',
+    mbti: '',
+    name: '',
+    nickname: '',
+    status: '',
+    thumbnail_url: '',
   },
 };
 
@@ -14,7 +20,10 @@ const userReducer = (prevState = initialState, action) => {
     case 'SET_USER_DATA':
       return { ...prevState, userData: action.data };
     case 'SET_MBTI':
-      return { ...prevState, userData: action.data };
+      return {
+        ...prevState,
+        userData: { ...prevState.userData, mbti: action.data },
+      };
     default:
       return prevState;
   }

--- a/src/redux/reducers/userReducer.ts
+++ b/src/redux/reducers/userReducer.ts
@@ -1,6 +1,8 @@
 const initialState = {
   LoggedIn: false,
-  userData: {},
+  userData: {
+    mbti: 'none',
+  },
 };
 
 const userReducer = (prevState = initialState, action) => {
@@ -12,7 +14,7 @@ const userReducer = (prevState = initialState, action) => {
     case 'SET_USER_DATA':
       return { ...prevState, userData: action.data };
     case 'SET_MBTI':
-      return { ...prevState, mbti: action.data };
+      return { ...prevState, userData: action.data };
     default:
       return prevState;
   }

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -141,7 +141,7 @@ export interface CheckValidProps {
   errorMessage: string;
 }
 
-export interface joinMBTI {
+export interface JoinMBTI {
   mbti?: string;
 }
 


### PR DESCRIPTION
### :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

### :: 구현 목표 
-  검사페이지에서 결과가 나와서 로그인이 되어 있다면 redux를 통해서 userdata의 mbti 결과값을 변경


<br />

### :: 구현 사항
<img width="1264" alt="스크린샷 2022-09-17 오후 10 00 35" src="https://user-images.githubusercontent.com/77052509/190858156-3d81206a-47a3-4dff-b84c-70896482ae10.png">






1. MBTI 테스트 페이지_FN_Login
-  검사페이지에서 20번째 질문까지 체크하면 나오는 버튼에 onClick으로 dispatch를 통해 mbti 결과 값을 변경해줌
- 마지막 페이지에서 onClick시 result 페이지로 이동 및 dispatch 함수 실행
- result 페이지에서 test 페이지에서 나온 결과값을 filter를 통해 목데이터에서 해당되는 mbti의 결과값을 가져와서 데이터를 UI에 반영해줌


<br>


### :: 특이 사항
- redux 에러 해결